### PR TITLE
Remove make/docker dependence.

### DIFF
--- a/packages/default/chess/build.sh
+++ b/packages/default/chess/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+set -e
+
 pushd ../../..
-make chess.go.zip
+echo "package main" > main/index.go
+echo 'var indexHTML = `<!DOCTYPE html>' >> main/index.go
+cat web/index.html | sed 's/ + "api\/default\/chess"//' >> main/index.go
+echo '`;' >> main/index.go
+zip -r packages/default/chess/chess.go.zip main
 popd
-cp ../../../chess.go.zip .


### PR DESCRIPTION
The Make build creates a requirement for both `make` and `docker` locally. This change allows for a deployment where the source is compiled at activation time instead.