### PR TITLE
Support deploying the frontend to Netlify and backend to Nimbella

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Here is a list of deployments in the various cloud:
 - [IBM Cloud](https://eu-de.functions.appdomain.cloud/api/v1/web/a1d40f6b-e5e3-4f07-8f92-77b525392253/default/chess)
 - [Naver](https://wka9bi13u3.apigw.ntruss.com/chess/chess/ZC2o7bFh0x/http)
 - [Nimbella](https://apigcp.nimbella.io/api/v1/web/msciabar-zc3thebgxgh/default/chess)
+- [Nimbella & Netlify](https://whisk-chess.netlify.app)
 
 You can read more on [this blog post](https://openwhisk.blog/portability).
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[[plugins]]
+package = "netlify-plugin-nimbella"
+
+[build]
+  base = "."
+  publish = "web"
+  command = "#"
+
+[nimbella]
+  # Base path that you want to use to access functions. Example https://your-site.com/api/default/greet
+  path = "/api/"


### PR DESCRIPTION
Adds the necessary config required to deploy the frontend (`web`) to Netlify and the backend (`packages`) to Nimbella using `netlify-plugin-nimbella`. 